### PR TITLE
Fixed Telegram's Flathub ID

### DIFF
--- a/applist.csv
+++ b/applist.csv
@@ -146,7 +146,7 @@ step,org.kde.step
 sublime-merge,com.sublimemerge.App
 sublime-text,com.sublimetext.three
 sweeper,org.kde.sweeper
-telegram-desktop,org.telegram
+telegram-desktop,org.telegram.desktop
 thunderbird,org.mozilla.Thunderbird
 tiled,org.mapeditor.Tiled
 todoist,com.todoist.Todoist


### PR DESCRIPTION
https://flathub.org/apps/details/org.telegram.desktop