### PR TITLE
which: use command -v instead of which as it's deprecated

### DIFF
--- a/unsnap
+++ b/unsnap
@@ -77,7 +77,7 @@ function check_for_snap() {
     # If snap doesn't exist or work, likelyhood is no snaps are installed either
     # so we exit out.
     echo "INFO: Checking for snap binary"  | tee -a "$LOGFILE"
-    if which snap > /dev/null; then 
+    if [ -x "$(command -v snap)" ]; then
         echo "INFO: snap found" | tee -a "$LOGFILE"
     else
         echo "ERROR: snapd doesn't appear to be installed, exiting." | tee -a "$LOGFILE"
@@ -209,7 +209,7 @@ function check_for_flatpak() {
     # Check if the flatpak binary exists, and if it doesn't call 
     # function to generate a script to install flatpak
     echo "INFO: Checking for flatpak binary" | tee -a "$LOGFILE"
-    if which flatpak > /dev/null; then
+    if [ -x "$(command -v flatpak)" ]; then
         echo "INFO: flatpak found no need to generate flatpak install script" | tee -a "$LOGFILE"
         check_for_flathub
     else


### PR DESCRIPTION
In Debian bookworm which is deprecated and shell scripts are
advised to use command -v instead.
https://wiki.debian.org/NewInBookworm