### PR TITLE
Add emacs and sweethome3d to applist

### DIFF
--- a/applist.csv
+++ b/applist.csv
@@ -29,6 +29,7 @@ digikam,org.kde.digikam
 discord,com.discordapp.Discord
 dragon,org.kde.dragon
 drawio,com.jgraph.drawio.desktop
+emacs,org.gnu.emacs
 eog,org.gnome.eog
 evince,org.gnome.Evince
 falkon,org.kde.falkon
@@ -196,6 +197,7 @@ sublime-merge,com.sublimemerge.App
 sublime-text,com.sublimetext.three
 supertuxkart,net.supertuxkart.SuperTuxKart
 sweeper,org.kde.sweeper
+sweethome3d-homedesign,com.sweethome3d.Sweethome3d
 tandem,chat.tandem.Client
 teeworlds-unofficial,com.teeworlds.Teeworlds
 telegram-desktop,org.telegram.desktop


### PR DESCRIPTION
Added the equivalent emacs and SweetHome3D flatpak package to the [applist.csv](https://github.com/popey/unsnap/pull/46/files#diff-1fd0e56c2d1782999b6b7b530b4581d4236b845c6059b29824482f51a80f0a0f)

| **snap package**       | **flathub package**         |
|------------------------|-----------------------------|
| [emacs ](https://snapcraft.io/emacs)                 | [org.gnu.emacs](https://flathub.org/apps/details/org.gnu.emacs)               |
| [sweethome3d-homedesign](https://snapcraft.io/sweethome3d-homedesign) | [com.sweethome3d.Sweethome3d](https://flathub.org/apps/details/com.sweethome3d.Sweethome3d) |
