### PR TITLE
'firmware-updater' snap should be replaced by 'org.gnome.Firmware'

### DIFF
--- a/applist.csv
+++ b/applist.csv
@@ -33,6 +33,7 @@ eog,org.gnome.eog
 evince,org.gnome.Evince
 falkon,org.kde.falkon
 firefox,org.mozilla.firefox
+firmware-updater,org.gnome.Firmware
 fluffychat,im.fluffychat.Fluffychat
 foliate,com.github.johnfactotum.Foliate
 fractal,org.gnome.Fractal


### PR DESCRIPTION
I'm running Ubuntu 23.10 and noticed this snap package didn't get replaced. It seems like `org.gnome.Firmware` is the appropriate replacement. 